### PR TITLE
feat(release): Add release workflow for versioned Docker image builds.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,19 @@
 on:
-  push:
-    branches:
-      - main
   pull_request:
-    branches:
-      - main
+    paths-ignore:
+      - 'docs/**'
+      - 'README.md'
+      - 'CHANGELOG.md'
+      - '.gitignore'
+      - '.gitattributes'
+
+  push:
+    paths-ignore:
+      - 'docs/**'
+      - 'README.md'
+      - 'CHANGELOG.md'
+      - '.gitignore'
+      - '.gitattributes'
 
 concurrency:
   group: build-${{ github.workflow }}-${{ github.ref }}
@@ -34,14 +43,6 @@ jobs:
 
     - name: Setup Docker Buildx.
       uses: docker/setup-buildx-action@v3
-
-    - name: Login to GitHub Container Registry.
-      if: github.event_name == 'push'  # Push events only; not on PRs
-      uses: docker/login-action@v3
-      with:
-        registry: ${{ env.REGISTRY }}
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Prepare tags.
       id: tags
@@ -77,22 +78,6 @@ jobs:
           BUILD_TYPE=${{ matrix.build_type }}
           PHP_VERSION=${{ steps.tags.outputs.PHP_VERSION }}
         cache-from: type=gha,scope=${{ github.head_ref || github.ref_name }}-${{ matrix.build_type }}
-        provenance: false
-        sbom: false
-
-    - name: Build and Push
-      if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
-      uses: docker/build-push-action@v6
-      with:
-        context: .
-        file: ./src/flavor/apache/Dockerfile
-        push: ${{ github.event_name == 'push' }}
-        tags: ${{ steps.tags.outputs.TAG }}
-        build-args: |
-          BUILD_TYPE=${{ matrix.build_type }}
-          PHP_VERSION=${{ steps.tags.outputs.PHP_VERSION }}
-        cache-from: type=gha,scope=${{ github.head_ref || github.ref_name }}-${{ matrix.build_type }}
-        cache-to: type=gha,mode=max,scope=${{ github.head_ref || github.ref_name }}-${{ matrix.build_type }}
         provenance: false
         sbom: false
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,5 @@
 on:
   pull_request:
-    branches:
-      - main
     paths-ignore:
       - 'docs/**'
       - 'README.md'
@@ -70,8 +68,7 @@ jobs:
           echo "TAG=${BASE_NAME}:${PHP_VERSION}-debian-${BUILD_TYPE}-${BRANCH_NAME}" >> $GITHUB_OUTPUT
         fi
 
-    - name: Build Only (PRs from Forks).
-      if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork
+    - name: Build Only.
       uses: docker/build-push-action@v6
       with:
         context: .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,7 @@
 on:
   pull_request:
+    branches:
+      - main
     paths-ignore:
       - 'docs/**'
       - 'README.md'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,8 @@ on:
       - '.gitattributes'
 
   push:
+    branches:
+      - main
     paths-ignore:
       - 'docs/**'
       - 'README.md'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,14 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: release-${{ github.ref || github.event.inputs.version }}
+  cancel-in-progress: true
+
 name: release
 
 env:
+  PHP_VERSION: '8.4'
   REGISTRY: ghcr.io
 
 jobs:
@@ -77,19 +82,24 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Compute build metadata.
+      id: meta
+      run: |
+        echo "created=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
     - name: Prepare tags.
       id: tags
       run: |
         BASE_NAME="${{ env.REGISTRY }}/${{ github.repository_owner }}/apache"
         VERSION="${{ needs.validate-version.outputs.version }}"
         BUILD_TYPE="${{ matrix.build_type }}"
-        PHP_VERSION="8.4"
+        PHP_VERSION="${{ env.PHP_VERSION }}"
 
         # Main tags with version
         TAGS="${BASE_NAME}:${VERSION}-${BUILD_TYPE}"
         TAGS="${TAGS},${BASE_NAME}:${PHP_VERSION}-${VERSION}-${BUILD_TYPE}"
 
-        # Latest tag for prod on main branch
+        # Latest tag for prod on version tags
         if [[ "$BUILD_TYPE" == "prod" && "${{ github.ref }}" == refs/tags/v* ]]; then
           TAGS="${TAGS},${BASE_NAME}:latest"
           TAGS="${TAGS},${BASE_NAME}:${PHP_VERSION}-latest"
@@ -108,14 +118,14 @@ jobs:
       with:
         context: .
         file: ./src/flavor/apache/Dockerfile
-        push: ${{ needs.validate-version.outputs.should_build == 'true' }}
+        push: true
         tags: ${{ steps.tags.outputs.tags }}
         build-args: |
           BUILD_TYPE=${{ matrix.build_type }}
-          PHP_VERSION=8.4
+          PHP_VERSION=${{ env.PHP_VERSION }}
           VERSION=${{ needs.validate-version.outputs.version }}
         labels: |
+          org.opencontainers.image.created=${{ steps.meta.outputs.created }}
           org.opencontainers.image.version=${{ needs.validate-version.outputs.version }}
-          org.opencontainers.image.created=${{ github.event.repository.updated_at }}
         cache-from: type=gha,scope=${{ matrix.build_type }}
         cache-to: type=gha,mode=max,scope=${{ matrix.build_type }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
         type: string
 
 concurrency:
-  group: release-${{ github.ref || github.event.inputs.version }}
+  group: release-${{ github.ref_type == 'tag' && github.ref_name || github.event.inputs.version }}
   cancel-in-progress: true
 
 name: release
@@ -61,6 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
       packages: write
 
     strategy:
@@ -90,6 +91,7 @@ jobs:
     - name: Prepare tags.
       id: tags
       run: |
+        set -Eeuo pipefail
         BASE_NAME="${{ env.REGISTRY }}/${{ github.repository_owner }}/apache"
         VERSION="${{ needs.validate-version.outputs.version }}"
         BUILD_TYPE="${{ matrix.build_type }}"
@@ -99,33 +101,35 @@ jobs:
         TAGS="${BASE_NAME}:${VERSION}-${BUILD_TYPE}"
         TAGS="${TAGS},${BASE_NAME}:${PHP_VERSION}-${VERSION}-${BUILD_TYPE}"
 
-        # Latest tag for prod on version tags
-        if [[ "$BUILD_TYPE" == "prod" && "${{ github.ref }}" == refs/tags/v* ]]; then
+        # Latest tag for prod on version tags or validated manual releases
+        if [[ "$BUILD_TYPE" == "prod" && ( "${{ github.ref }}" == refs/tags/v* || "${{ github.event_name }}" == "workflow_dispatch" ) ]]; then
           TAGS="${TAGS},${BASE_NAME}:latest"
           TAGS="${TAGS},${BASE_NAME}:${PHP_VERSION}-latest"
         fi
 
         # Build type latest
-        if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+        if [[ "${{ github.ref }}" == refs/tags/v* || "${{ github.event_name }}" == "workflow_dispatch" ]]; then
           TAGS="${TAGS},${BASE_NAME}:${BUILD_TYPE}-latest"
         fi
 
-        echo "tags=$TAGS" >> $GITHUB_OUTPUT
+        printf 'tags=%s\n' "$TAGS" >> "$GITHUB_OUTPUT"
         echo "📦 Tags: $TAGS"
 
     - name: Build and Push.
       uses: docker/build-push-action@v6
       with:
-        context: .
-        file: ./src/flavor/apache/Dockerfile
-        push: true
-        tags: ${{ steps.tags.outputs.tags }}
         build-args: |
           BUILD_TYPE=${{ matrix.build_type }}
           PHP_VERSION=${{ env.PHP_VERSION }}
           VERSION=${{ needs.validate-version.outputs.version }}
+        cache-from: type=gha,scope=${{ matrix.build_type }}
+        cache-to: type=gha,mode=max,scope=${{ matrix.build_type }}
+        context: .
+        file: ./src/flavor/apache/Dockerfile
         labels: |
           org.opencontainers.image.created=${{ steps.meta.outputs.created }}
           org.opencontainers.image.version=${{ needs.validate-version.outputs.version }}
-        cache-from: type=gha,scope=${{ matrix.build_type }}
-        cache-to: type=gha,mode=max,scope=${{ matrix.build_type }}
+        provenance: true
+        push: true
+        sbom: true
+        tags: ${{ steps.tags.outputs.tags }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,12 +35,6 @@ jobs:
         elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
           VERSION="${{ github.event.inputs.version }}"
           SHOULD_BUILD="true"
-        # From PR title (optional)
-        elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
-          if [[ "${{ github.event.pull_request.title }}" =~ \[v([0-9]+\.[0-9]+\.[0-9]+)\] ]]; then
-            VERSION="${BASH_REMATCH[1]}"
-            SHOULD_BUILD="true"
-          fi
         fi
 
         # Validate semantic version
@@ -111,7 +105,7 @@ jobs:
       with:
         context: .
         file: ./src/flavor/apache/Dockerfile
-        push: ${{ github.ref_type == 'tag' }}
+        push: ${{ needs.validate-version.outputs.should_build == 'true' }}
         tags: ${{ steps.tags.outputs.tags }}
         build-args: |
           BUILD_TYPE=${{ matrix.build_type }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,27 +23,30 @@ jobs:
     steps:
     - name: Extract version.
       id: version
+      env:
+        INPUT_VERSION: ${{ github.event.inputs.version }}
       run: |
+        set -Eeuo pipefail
         VERSION=""
         SHOULD_BUILD="false"
 
         # From tag
-        if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
-          VERSION="${GITHUB_REF#refs/tags/v}"
+        if [[ "${GITHUB_REF_NAME:-}" == v* ]]; then
+          VERSION="${GITHUB_REF_NAME#v}"
           SHOULD_BUILD="true"
         # From workflow dispatch
         elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-          VERSION="${{ github.event.inputs.version }}"
+          VERSION="$INPUT_VERSION"
           SHOULD_BUILD="true"
         fi
 
         # Validate semantic version
         if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "should_build=$SHOULD_BUILD" >> $GITHUB_OUTPUT
+          printf 'version=%s\n' "$VERSION" >> "$GITHUB_OUTPUT"
+          printf 'should_build=%s\n' "$SHOULD_BUILD" >> "$GITHUB_OUTPUT"
           echo "✅ Valid version: $VERSION"
         else
-          echo "should_build=false" >> $GITHUB_OUTPUT
+          echo "should_build=false" >> "$GITHUB_OUTPUT"
           echo "⚠️ No valid version found"
         fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,124 @@
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to build (for example, 1.0.0)'
+        required: true
+        type: string
+
+name: release
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  validate-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      should_build: ${{ steps.version.outputs.should_build }}
+    steps:
+    - name: Extract version.
+      id: version
+      run: |
+        VERSION=""
+        SHOULD_BUILD="false"
+
+        # From tag
+        if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          SHOULD_BUILD="true"
+        # From workflow dispatch
+        elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+          VERSION="${{ github.event.inputs.version }}"
+          SHOULD_BUILD="true"
+        # From PR title (optional)
+        elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
+          if [[ "${{ github.event.pull_request.title }}" =~ \[v([0-9]+\.[0-9]+\.[0-9]+)\] ]]; then
+            VERSION="${BASH_REMATCH[1]}"
+            SHOULD_BUILD="true"
+          fi
+        fi
+
+        # Validate semantic version
+        if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "should_build=$SHOULD_BUILD" >> $GITHUB_OUTPUT
+          echo "✅ Valid version: $VERSION"
+        else
+          echo "should_build=false" >> $GITHUB_OUTPUT
+          echo "⚠️ No valid version found"
+        fi
+
+  build:
+    needs: validate-version
+    if: needs.validate-version.outputs.should_build == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type: [dev, full, prod]
+
+    steps:
+    - name: Checkout.
+      uses: actions/checkout@v5
+
+    - name: Setup Docker Buildx.
+      uses: docker/setup-buildx-action@v3
+
+    - name: Login to GitHub Container Registry.
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Prepare tags.
+      id: tags
+      run: |
+        BASE_NAME="${{ env.REGISTRY }}/${{ github.repository_owner }}/apache"
+        VERSION="${{ needs.validate-version.outputs.version }}"
+        BUILD_TYPE="${{ matrix.build_type }}"
+        PHP_VERSION="8.4"
+
+        # Main tags with version
+        TAGS="${BASE_NAME}:${VERSION}-${BUILD_TYPE}"
+        TAGS="${TAGS},${BASE_NAME}:${PHP_VERSION}-${VERSION}-${BUILD_TYPE}"
+
+        # Latest tag for prod on main branch
+        if [[ "$BUILD_TYPE" == "prod" && "${{ github.ref }}" == refs/tags/v* ]]; then
+          TAGS="${TAGS},${BASE_NAME}:latest"
+          TAGS="${TAGS},${BASE_NAME}:${PHP_VERSION}-latest"
+        fi
+
+        # Build type latest
+        if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+          TAGS="${TAGS},${BASE_NAME}:${BUILD_TYPE}-latest"
+        fi
+
+        echo "tags=$TAGS" >> $GITHUB_OUTPUT
+        echo "📦 Tags: $TAGS"
+
+    - name: Build and Push.
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: ./src/flavor/apache/Dockerfile
+        push: ${{ github.ref_type == 'tag' }}
+        tags: ${{ steps.tags.outputs.tags }}
+        build-args: |
+          BUILD_TYPE=${{ matrix.build_type }}
+          PHP_VERSION=8.4
+          VERSION=${{ needs.validate-version.outputs.version }}
+        labels: |
+          org.opencontainers.image.version=${{ needs.validate-version.outputs.version }}
+          org.opencontainers.image.created=${{ github.event.repository.updated_at }}
+        cache-from: type=gha,scope=${{ matrix.build_type }}
+        cache-to: type=gha,mode=max,scope=${{ matrix.build_type }}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a release workflow to build and publish versioned Docker images (tag-triggered and manual), producing dev/full/prod variants with multiple tags, metadata, and caching.

* **Chores**
  * PRs (including forks) run build-only without pushing images.
  * Pushes to main no longer publish; publishing happens via the release workflow.
  * CI now cancels in-progress runs for newer commits.
  * Removed registry login from the standard build flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->