### PR TITLE
fix(apache): Improve Brotli and Gzip compression settings for enhanced performance and compatibility.

### DIFF
--- a/src/etc/apache2/conf-available/04-compression.conf
+++ b/src/etc/apache2/conf-available/04-compression.conf
@@ -28,7 +28,6 @@
         application/xml \
         font/opentype \
         image/svg+xml \
-        image/x-icon \
         text/cache-manifest \
         text/css \
         text/html \
@@ -77,7 +76,6 @@
         application/xml \
         font/opentype \
         image/svg+xml \
-        image/x-icon \
         text/cache-manifest \
         text/css \
         text/html \


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Broader server-side compression for many additional content types (fonts, manifests, wasm, RSS/ATOM, LD+JSON, SVG, etc.) to reduce transfer sizes.
  * Prefer Brotli when supported, with tuned gzip/deflate fallback settings for steadier throughput.
  * Skip already-compressed media (AVIF, JXL, HEIC/HEIF, PDF, MP3/MP4, AVI, MOV, WMV, FLV, WebM, MKV, SVGZ).
  * Ensure caches respect encoding via merged Vary: Accept-Encoding and avoid compressing streaming event responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->