### PR TITLE
fix(build): Add permissions for actions and contents in build job configuration.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    permissions:
+      actions: write
+      contents: read
+
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow configuration to adjust permissions for the build job, enabling write access to Actions and read access to repository contents.
  * No changes to build steps, triggers, or control flow; only the job’s permission scope was updated.
  * This affects CI infrastructure behavior only and does not impact application functionality or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->