### PR TITLE
fix(release): Disable provenance and SBOM generation in Docker build metadata.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,9 +111,9 @@ jobs:
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.url=https://github.com/${{ github.repository }}
             org.opencontainers.image.version=${{ env.BUILD_VERSION }}
-          provenance: true
+          provenance: false
           push: true
-          sbom: true
+          sbom: false
           tags: ${{ steps.tags.outputs.tags }}
 
       - name: Show build result


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release pipeline to stop generating provenance metadata and software bills of materials for container images.
  * Simplifies image builds and may reduce build time and artifact size during releases.
  * No user-facing changes; application behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->